### PR TITLE
Separate submit view to respond with JSON not redirect

### DIFF
--- a/dam/middleware.py
+++ b/dam/middleware.py
@@ -80,6 +80,7 @@ class AltchaMiddleware(MiddlewareMixin):
             return None
         # Redirect to Altcha verification page
         dam_url = f'{reverse("dam:challenge")}?next={quote_plus(request.get_full_path())}'
+        request.session[f'referer{request.get_full_path()}'] = request.META.get('HTTP_REFERER', '')
         return redirect(dam_url)
 
 

--- a/dam/templates/dam_challenge.html
+++ b/dam/templates/dam_challenge.html
@@ -9,11 +9,11 @@
     <script async defer src="{{ js_src_url }}" type="module"></script>
 </head>
 <body>
-    <div>
+    <div id="altcha-content">
         <h1><img src="{{ site_icon_url }}"> {{ request.get_host }}</h1>
         <h2>{{ altcha_message }}</h2>
         <div>
-            <form id="altcha-submission" action="{% url 'dam:challenge' %}" method="POST">
+            <form id="altcha-submission">
                 {% csrf_token %}
                 <input type="hidden" name="next" value="{{ next_url }}">
                 <altcha-widget id="altcha"></altcha-widget>
@@ -37,11 +37,26 @@
                 hidelogo: false,
             });
         });
-        document.querySelector("altcha-widget").addEventListener("statechange", (ev) => {
-            if (ev.detail.state === "verified") {
-                setTimeout(() => {
-                    document.forms["altcha-submission"].submit();
-                }, 1000);
+        document.querySelector("altcha-widget").addEventListener("statechange", async (ev) => {
+            if (await ev.detail.state === "verified") {
+                const challengeData = new FormData(document.forms["altcha-submission"]);
+                try {
+                   const response = await fetch("{% url 'dam:submit_challenge' %}", {
+                        method: "POST",
+                        body: challengeData,
+                    });
+                    const result = await response.json();
+                    if ("success" in result) {
+                        if ("{{ original_referrer }}") {
+                            window.history.replaceState({}, "" , "{{ original_referrer }}");
+                        }
+                        window.location.replace("{{ next_url }}");
+                    } else {
+                        document.getElementById('altcha-content').textContent = result.error;
+                    }
+                } catch (error) {
+                    console.error("Challenge submission error:", error);
+                }
             }
         });
     </script>

--- a/dam/templates/dam_challenge.html
+++ b/dam/templates/dam_challenge.html
@@ -37,8 +37,9 @@
                 hidelogo: false,
             });
         });
-        document.querySelector("altcha-widget").addEventListener("statechange", async (ev) => {
-            if (await ev.detail.state === "verified") {
+        document.querySelector("altcha-widget").addEventListener("statechange", async (e) => {
+            await e.detail;
+            if (e.detail.state === "verified") {
                 const challengeData = new FormData(document.forms["altcha-submission"]);
                 try {
                    const response = await fetch("{% url 'dam:submit_challenge' %}", {

--- a/dam/urls.py
+++ b/dam/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from dam.views import dam_challenge
+from dam.views import dam_challenge, submit_challenge
 
 
 app_name = 'dam'
 
 urlpatterns = [
     path('dam/', dam_challenge, name='challenge'),
+    path('dam/submit/', submit_challenge, name='submit_challenge'),
 ]

--- a/dam/views.py
+++ b/dam/views.py
@@ -5,57 +5,61 @@ from base64 import b64decode
 
 
 from django.conf import settings
-from django.http import HttpResponse
-from django.shortcuts import render, redirect
+from django.http import JsonResponse
+from django.shortcuts import render
 from django.core.cache import cache
+from django.views.decorators.http import require_GET, require_POST
 from altcha import create_challenge, verify_solution
 
 
+@require_GET
 def dam_challenge(request):
-    """Make the user solve an Altcha challenge before allowing access."""
-    # For POST requests, check the challenge response and see if it validates
-    if request.method == 'POST':
-        try:
-            payload = json.loads(b64decode(request.POST.get('altcha')))
-        except Exception:
-            payload = {}
-        ok, err = verify_solution(payload, settings.ALTCHA_HMAC_KEY, check_expires=True)
-        destination = request.POST.get('next', ['/'])
-        # If the solution validates and hasn't already been seen, create/update their session dam
-        # expiration and send them off, as well as saving the challenge in cache.
-        if (isinstance(payload, dict) and ok and destination
-                and not cache.get(payload.get('challenge'))):
-            challenge_expire_mins = getattr(settings, 'ALTCHA_CHALLENGE_EXPIRE_MINUTES', 2)
-            auth_expire_mins = getattr(settings, 'ALTCHA_AUTH_EXPIRE_MINUTES', 480)
-            cache.set(
-                payload['challenge'],
-                't',
-                timeout=challenge_expire_mins*60)
-            altcha_session_key = getattr(settings, 'ALTCHA_SESSION_KEY', 'altcha_verified')
-            request.session[altcha_session_key] = time.time() + auth_expire_mins*60
-            return redirect(destination)
-        # Otherwise, reject them.
-        return HttpResponse('Challenge failed or no longer valid.', status=400)
-    # For normal requests, create the challenge and send it.
-    else:
+    """Provide user an Altcha challenge to solve before allowing access."""
+    challenge_expire_mins = getattr(settings, 'ALTCHA_CHALLENGE_EXPIRE_MINUTES', 2)
+    challenge = create_challenge(
+        expires=datetime.datetime.now() + datetime.timedelta(minutes=challenge_expire_mins),
+        max_number=settings.ALTCHA_MAX_NUMBER,
+        hmac_key=settings.ALTCHA_HMAC_KEY,
+        # Use the params to add arbitrary values to the salt, potentially increasing security
+        params=getattr(settings, 'ALTCHA_SALT_PARAMS', {}),
+    )
+    next_url = request.GET.get('next', '/')
+    return render(
+        request,
+        'dam_challenge.html',
+        {
+            'challenge': challenge,
+            'site_icon_url': getattr(settings, 'ALTCHA_SITE_ICON_URL', ''),
+            'js_src_url': getattr(settings, 'ALTCHA_JS_URL', '/static/altcha/altcha.min.js'),
+            'altcha_message': getattr(settings,
+                                      'ALTCHA_MESSAGE',
+                                      'Gauging your humanity...This may take some seconds.'),
+            'next_url': next_url,
+            'original_referrer': request.session.get(f'referer{next_url}', ''),
+        }
+    )
+
+
+@require_POST
+def submit_challenge(request):
+    """Attempt to validate Altcha challenge solution."""
+    try:
+        payload = json.loads(b64decode(request.POST.get('altcha')))
+    except Exception:
+        payload = {}
+    ok, err = verify_solution(payload, settings.ALTCHA_HMAC_KEY, check_expires=True)
+    # If the solution validates and hasn't already been seen, create/update their session dam
+    # expiration, as well as saving the challenge in cache.
+    if (isinstance(payload, dict) and ok
+            and not cache.get(payload.get('challenge'))):
         challenge_expire_mins = getattr(settings, 'ALTCHA_CHALLENGE_EXPIRE_MINUTES', 2)
-        challenge = create_challenge(
-            expires=datetime.datetime.now() + datetime.timedelta(minutes=challenge_expire_mins),
-            max_number=settings.ALTCHA_MAX_NUMBER,
-            hmac_key=settings.ALTCHA_HMAC_KEY,
-            # Use the params to add arbitrary values to the salt, potentially increasing security
-            params=getattr(settings, 'ALTCHA_SALT_PARAMS', {}),
-        )
-        return render(
-            request,
-            'dam_challenge.html',
-            {
-                'challenge': challenge,
-                'site_icon_url': getattr(settings, 'ALTCHA_SITE_ICON_URL', ''),
-                'js_src_url': getattr(settings, 'ALTCHA_JS_URL', '/static/altcha/altcha.min.js'),
-                'altcha_message': getattr(settings,
-                                          'ALTCHA_MESSAGE',
-                                          'Gauging your humanity...This may take some seconds.'),
-                'next_url': request.GET.get('next', '/'),
-            }
-        )
+        auth_expire_mins = getattr(settings, 'ALTCHA_AUTH_EXPIRE_MINUTES', 480)
+        cache.set(
+            payload['challenge'],
+            't',
+            timeout=challenge_expire_mins*60)
+        altcha_session_key = getattr(settings, 'ALTCHA_SESSION_KEY', 'altcha_verified')
+        request.session[altcha_session_key] = time.time() + auth_expire_mins*60
+        return JsonResponse({'success': True})
+    # Otherwise, reject them.
+    return JsonResponse({'error': 'Challenge failed or no longer valid.'}, status=400)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -13,7 +13,7 @@ class TestDamChallengeView:
     def test_get_request_serves_challenge_page(self, client):
         """A GET request should serve the challenge page."""
         settings.ALTCHA_SALT_PARAMS = {'some': 'thing'}
-        response = client.get('/dam/?next=%2Fprotected%2F', follow=True)
+        response = client.get('/dam/?next=%2Fprotected%2F')
         assert response.context['challenge'].max_number == settings.ALTCHA_MAX_NUMBER
         assert hasattr(response.context['challenge'], 'challenge')
         assert response.context['challenge'].salt.endswith('&some=thing')
@@ -23,16 +23,18 @@ class TestDamChallengeView:
         assert response.context['js_src_url'] == settings.ALTCHA_JS_URL
         assert response.context['site_icon_url'] == settings.ALTCHA_SITE_ICON_URL
         assert response.context['next_url'] == '/protected/'
-        assert response.redirect_chain == []
+
+
+class TestSubmitChallengeView:
+    """Unit tests for submit_challenge view."""
 
     @pytest.mark.django_db
     @patch('dam.views.verify_solution', return_value=[False, None])
     def test_post_request_fails_with_no_payload(self, mock_verify_solution, client):
         """A POST request with no payload should return a 400."""
-        response = client.post('/dam/?next=%2Fprotected%2F', follow=True)
+        response = client.post('/dam/submit/')
         assert response.status_code == 400
-        assert response.content.decode() == 'Challenge failed or no longer valid.'
-        assert response.redirect_chain == []
+        assert response.content.decode() == '{"error": "Challenge failed or no longer valid."}'
         mock_verify_solution.assert_called_once_with(
             {}, settings.ALTCHA_HMAC_KEY, check_expires=True)
         assert client.session.get(settings.ALTCHA_SESSION_KEY) is None
@@ -41,15 +43,16 @@ class TestDamChallengeView:
     @patch('dam.views.time.time', return_value=1.0)
     @patch('dam.views.verify_solution', return_value=[True, None])
     def test_post_request_valid_challenge_response(self, mock_verify_solution, mock_time, client):
-        """Valid POST request with good payload redirects to requested page."""
+        """Valid POST request with good payload responds with success."""
         payload = {'challenge': '1234abcd'}
         payload_b64_encoded = base64.b64encode(json.dumps(payload).encode()).decode()
         assert not cache.get(payload['challenge'])
-        response = client.post('/dam/?next=%2Fprotected%2F', {'altcha': payload_b64_encoded,
-                                                              'next': '/protected/'}, follow=True)
+        response = client.post('/dam/submit/', {'altcha': payload_b64_encoded,
+                                                'next': '/protected/'})
+        assert response.status_code == 200
+        assert response.content.decode() == '{"success": true}'
         mock_verify_solution.assert_called_once_with(payload, settings.ALTCHA_HMAC_KEY,
                                                      check_expires=True)
-        assert response.redirect_chain == [('/protected/', 302)]
         expected_auth_expiration = settings.ALTCHA_AUTH_EXPIRE_MINUTES * 60 + 1.0
         assert client.session[settings.ALTCHA_SESSION_KEY] == expected_auth_expiration
         assert cache.get(payload['challenge'])
@@ -61,13 +64,12 @@ class TestDamChallengeView:
         payload = {'challenge': '1234abcd'}
         payload_b64_encoded = base64.b64encode(json.dumps(payload).encode()).decode()
         assert not cache.get(payload['challenge'])
-        response = client.post('/dam/?next=%2Fprotected%2F', {'altcha': payload_b64_encoded,
-                                                              'next': '/protected/'}, follow=True)
+        response = client.post('/dam/submit/', {'altcha': payload_b64_encoded,
+                                                'next': '/protected/'})
         mock_verify_solution.assert_called_once_with(payload, settings.ALTCHA_HMAC_KEY,
                                                      check_expires=True)
-        assert response.redirect_chain == []
         assert response.status_code == 400
-        assert response.content.decode() == 'Challenge failed or no longer valid.'
+        assert response.content.decode() == '{"error": "Challenge failed or no longer valid."}'
         assert client.session.get(settings.ALTCHA_SESSION_KEY) is None
         assert not cache.get(payload['challenge'])
 
@@ -78,11 +80,10 @@ class TestDamChallengeView:
         payload = {'challenge': '1234abcd'}
         payload_b64_encoded = base64.b64encode(json.dumps(payload).encode()).decode()
         cache.set(payload['challenge'], 't', timeout=settings.ALTCHA_AUTH_EXPIRE_MINUTES*60)
-        response = client.post('/dam/?next=%2Fprotected%2F', {'altcha': payload_b64_encoded,
-                                                              'next': '/protected/'}, follow=True)
+        response = client.post('/dam/submit/', {'altcha': payload_b64_encoded,
+                                                'next': '/protected/'})
         mock_verify_solution.assert_called_once_with(payload, settings.ALTCHA_HMAC_KEY,
                                                      check_expires=True)
-        assert response.redirect_chain == []
         assert response.status_code == 400
-        assert response.content.decode() == 'Challenge failed or no longer valid.'
+        assert response.content.decode() == '{"error": "Challenge failed or no longer valid."}'
         assert client.session.get(settings.ALTCHA_SESSION_KEY) is None

--- a/tests/views.py
+++ b/tests/views.py
@@ -8,4 +8,5 @@ def protected_view(request, *args, **kwargs):
 
 
 def open_view(request, *args, **kwargs):
-    return HttpResponse('This view is open to anyone.')
+    return HttpResponse('This view is open to anyone. '
+                        'View a <a href="/protected/">protected</a> page.')


### PR DESCRIPTION
This splits off part of the challenge view into a separate submit view. The code for those views largely remains the same, except that on submitting a successful challenge, the view now returns a JSON response instead of a redirect. This, along with now storing on the session the original referrer for a URL that leads to a challenge view, facilitates leaving the /dam view out of a browser's history by using `window.location.replace` to load the content requested by the user (as opposed to having the server respond with a redirect).

Additionally, this makes use of `window.history.replaceState` to adjust the browser's history for allowing the  HTTP referer header sent when loading content after a successful challenge to remain what it would have been if not encountering the dam middleware.

This is ready for review @somexpert @clarktr1 . If you want to share thoughts or suggestions about alternate implementations to handle retaining the original referer header or keeping the /dam view out of the browser history, please feel free to share. Thank you!