### PR TITLE
Allow optional help text on challenge and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ To install this app into your existing Django project:
     ALTCHA_JS_URL = '/static/altcha/altcha.min.js'  # Where to find the altcha widget JS.
     ALTCHA_MESSAGE = ('Gauging your humanity...'    # Message to present to users on the challenge page.
                       'This may take some seconds.')
-	ALTCHA_FAIL_MESSAGE = ('Challenge failed or no' # Message to show users when their challenge response is unsuccessful.
-						   ' longer valid.')
+    ALTCHA_HELP_MESSAGE = ''                        # Message shown on challenge page and in errors indicating how to seek help on challenge failure/error.
+    ALTCHA_FAIL_MESSAGE = ('Challenge failed or no' # Message to show users when their challenge response is unsuccessful.
+                           ' longer valid.')
     ALTCHA_EXCLUDE_PATHS = set()                    # Set of paths to exclude from challenges.
     ALTCHA_EXCLUDE_IPS = []                         # List of strings representing CIDRs or IPs to never challenge.
     ALTCHA_EXCLUDE_HEADERS = {}                     # Dict of HTTP header keys (case insensitive) with values to exempt from challenge.

--- a/dam/static/dam/dam.css
+++ b/dam/static/dam/dam.css
@@ -9,12 +9,15 @@
   --altcha-color-footer-bg: #f4f4f4;
 }
 
-h1, h2 {
+#altcha-content {
+  color: #474747;
+  font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+
+h1, h2, h3 {
   max-width: 45%;
   margin-left: auto;
   margin-right: auto;
-  color: #474747;
-  font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 h1 {
@@ -23,6 +26,11 @@ h1 {
 
 h2 {
   margin-top: auto;
+  font-weight: normal;
+}
+
+h3 {
+  margin-top: 1em;
   font-weight: normal;
 }
 

--- a/dam/templates/dam_challenge.html
+++ b/dam/templates/dam_challenge.html
@@ -19,6 +19,9 @@
                 <altcha-widget id="altcha"></altcha-widget>
             </form>
         </div>
+        {% if help_text %}
+            <h3>{{ help_text }}</h3>
+        {% endif %}
     </div>
     <script type="text/javascript">
         window.addEventListener("load", () => {
@@ -53,9 +56,10 @@
                         }
                         window.location.replace("{{ next_url }}");
                     } else {
-                        document.getElementById('altcha-content').textContent = result.error;
+                        document.getElementById('altcha-content').textContent = result.error + " " + "{{ help_text }}";
                     }
                 } catch (error) {
+                    document.getElementById('altcha-content').textContent = error + " " + "{{ help_text }}";
                     console.error("Challenge submission error:", error);
                 }
             }

--- a/dam/templates/dam_challenge.html
+++ b/dam/templates/dam_challenge.html
@@ -56,7 +56,7 @@
                         }
                         window.location.replace("{{ next_url }}");
                     } else {
-                        document.getElementById('altcha-content').textContent = result.error + " " + "{{ help_text }}";
+                        document.getElementById('altcha-content').textContent = `${result.error} {{ help_text }}`;
                     }
                 } catch (error) {
                     document.getElementById('altcha-content').textContent = error + " " + "{{ help_text }}";

--- a/dam/templates/dam_challenge.html
+++ b/dam/templates/dam_challenge.html
@@ -59,7 +59,7 @@
                         document.getElementById('altcha-content').textContent = `${result.error} {{ help_text }}`;
                     }
                 } catch (error) {
-                    document.getElementById('altcha-content').textContent = error + " " + "{{ help_text }}";
+                    document.getElementById('altcha-content').textContent = `${error} {{ help_text }}`;
                     console.error("Challenge submission error:", error);
                 }
             }

--- a/dam/views.py
+++ b/dam/views.py
@@ -37,8 +37,8 @@ def dam_challenge(request):
             'next_url': next_url,
             'original_referrer': request.session.get(f'referer{next_url}', ''),
             'help_text': getattr(settings,
-                                'ALTCHA_HELP_MESSAGE',
-                                ''),
+                                 'ALTCHA_HELP_MESSAGE',
+                                 ''),
         }
     )
 

--- a/dam/views.py
+++ b/dam/views.py
@@ -36,6 +36,9 @@ def dam_challenge(request):
                                       'Gauging your humanity...This may take some seconds.'),
             'next_url': next_url,
             'original_referrer': request.session.get(f'referer{next_url}', ''),
+            'help_text': getattr(settings,
+                                'ALTCHA_HELP_MESSAGE',
+                                ''),
         }
     )
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -16,6 +16,8 @@ ALTCHA_JS_URL = '/static/altcha/altcha.min.js'
 
 ALTCHA_MESSAGE = 'Gauging your humanity...This may take some seconds.'
 
+ALTCHA_HELP_MESSAGE = ''
+
 ALTCHA_FAIL_MESSAGE = 'Challenge failed or no longer valid.'
 
 ALTCHA_EXCLUDE_PATHS = []


### PR DESCRIPTION
This adds a setting for optional text to appear under the verify widget that we can use to indicate how a user can seek help if they are not able to pass the challenge or need to be whitelisted etc. Also removes tabs used with the ALTCHA_FAIL_MESSAGE in the README.