### PR TITLE
Pass original referrer as a parameter on challenge page

### DIFF
--- a/dam/middleware.py
+++ b/dam/middleware.py
@@ -79,9 +79,11 @@ class AltchaMiddleware(MiddlewareMixin):
         elif self.exclude_headers(request):
             # Request includes HTTP header with value exempt from verification.
             return None
+        referrer = request.headers.get('Referer')
         # Redirect to Altcha verification page
         dam_url = f'{reverse("dam:challenge")}?next={quote_plus(request.get_full_path())}'
-        request.session[f'referer{request.get_full_path()}'] = request.META.get('HTTP_REFERER', '')
+        if referrer:
+            dam_url += f'&prev={quote_plus(referrer)}'
         return redirect(dam_url)
 
 

--- a/dam/templates/dam_challenge.html
+++ b/dam/templates/dam_challenge.html
@@ -15,7 +15,6 @@
         <div>
             <form id="altcha-submission">
                 {% csrf_token %}
-                <input type="hidden" name="next" value="{{ next_url }}">
                 <altcha-widget id="altcha"></altcha-widget>
             </form>
         </div>
@@ -51,9 +50,6 @@
                     });
                     const result = await response.json();
                     if ("success" in result) {
-                        if ("{{ original_referrer }}") {
-                            window.history.replaceState({}, "" , "{{ original_referrer }}");
-                        }
                         window.location.replace("{{ next_url }}");
                     } else {
                         document.getElementById('altcha-content').innerHTML = `${result.error} {{ help_text|safe }}`;

--- a/dam/views.py
+++ b/dam/views.py
@@ -38,7 +38,6 @@ def dam_challenge(request):
                                       'ALTCHA_MESSAGE',
                                       'Gauging your humanity...This may take some seconds.'),
             'next_url': next_url,
-            'original_referrer': request.session.get(f'referer{next_url}', ''),
             'help_text': getattr(settings,
                                  'ALTCHA_HELP_MESSAGE',
                                  ''),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'dam'
-version = '1.0.0'
+version = '1.0.1'
 description = 'A Django app allowing you to protect views with an ALTCHA proof-of-work challenge.'
 readme = 'README.md'
 authors = [{name='University of North Texas Libraries', email='mark.phillips@unt.edu'}]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -148,6 +148,19 @@ class TestAltchaMiddleware:
         assert response.status_code == 302
         assert response.url == reverse('dam:challenge')+'?next=%2Fprotected%2F%3Fsearch%3Dstuff'
 
+    @pytest.mark.django_db
+    def test_process_request_challenge_user_has_referrer(self, rf):
+        mock_get_response = Mock()
+        AM = AltchaMiddleware(mock_get_response)
+        AM.exclude_ip = Mock(return_value=False)
+        request = rf.get('/protected/?search=stuff')
+        request.session = {}
+        request.headers = {'Referer': 'https://example.com/search?q=unt'}
+        response = AM.process_request(request)
+        assert response.status_code == 302
+        assert response.url == (f'{reverse("dam:challenge")}?next=%2Fprotected%2F%3Fsearch%3Dstuff'
+                                f'&prev=https%3A%2F%2Fexample.com%2Fsearch%3Fq%3Dunt')
+
 
 class TestMakeIPList:
     def test_make_ip_list(self, capsys):


### PR DESCRIPTION
This should help with a couple things:
- Removes using replaceState, which causes a security error with different origin referrers
-  Allows our stats processing to glean the original referrer for dam protected views from our httpd log lines

The changes are up on Alpha DL where you can see the changes in the challenge page query parameter and in the access log referrer field.

ping @somexpert @clarktr1 this is ready for review