### PR TITLE
Check ip address

### DIFF
--- a/dam/middleware.py
+++ b/dam/middleware.py
@@ -67,10 +67,15 @@ class AltchaMiddleware(MiddlewareMixin):
     def process_request(self, request):
         dam_paths = {reverse('dam:challenge'), reverse('dam:submit_challenge')}
         if time.time() <= request.session.get(self.altcha_session_key, 0):
-            # User already passed Altcha verification, their approval hasn't expired yet,
-            # and they are still using the same IP address.
-            if request.session.get('ip') == get_client_ip(request):
+            # User already passed Altcha verification, and their approval hasn't expired yet.
+            client_ip = get_client_ip(request)
+            if request.session.get('ip') == client_ip:
+                # Client is still using the same IP address, so good.
                 return None
+            else:
+                # Session user has changed IP address, expire their Altcha verification.
+                request.session[self.altcha_session_key] = 0
+                request.session['ip'] = client_ip
         if request.path in dam_paths | set(self.excluded_paths):
             # Path is exempt from Altcha verification.
             return None

--- a/dam/middleware.py
+++ b/dam/middleware.py
@@ -40,8 +40,7 @@ class AltchaMiddleware(MiddlewareMixin):
         if not self.excluded_ips:
             # There are no excluded IP addresses.
             return False
-        client_ip = request.META.get('HTTP_X_FORWARDED_FOR',
-                                     request.META.get('REMOTE_ADDR')).split(',')[0]
+        client_ip = get_client_ip(request)
         try:
             client_ip = ipaddress.ip_address(client_ip)
         except ValueError:
@@ -68,9 +67,11 @@ class AltchaMiddleware(MiddlewareMixin):
     def process_request(self, request):
         dam_paths = {reverse('dam:challenge'), reverse('dam:submit_challenge')}
         if time.time() <= request.session.get(self.altcha_session_key, 0):
-            # User already passed Altcha verification and their approval hasn't expired yet.
-            return None
-        elif request.path in dam_paths | set(self.excluded_paths):
+            # User already passed Altcha verification, their approval hasn't expired yet,
+            # and they are still using the same IP address.
+            if request.session.get('ip') == get_client_ip(request):
+                return None
+        if request.path in dam_paths | set(self.excluded_paths):
             # Path is exempt from Altcha verification.
             return None
         elif self.exclude_ip(request):
@@ -106,3 +107,8 @@ def make_ip_list(ip_addresses):
 def make_excluded_headers(header_exclusions):
     """Convert headers' string values into case-insensitive regular expression patterns."""
     return {k: re.compile(v, re.I) for k, v in header_exclusions.items()}
+
+
+def get_client_ip(request):
+    return request.META.get('HTTP_X_FORWARDED_FOR',
+                            request.META.get('REMOTE_ADDR')).split(',')[0]

--- a/dam/views.py
+++ b/dam/views.py
@@ -11,6 +11,8 @@ from django.core.cache import cache
 from django.views.decorators.http import require_GET, require_POST
 from altcha import create_challenge, verify_solution
 
+from dam.middleware import get_client_ip
+
 
 @require_GET
 def dam_challenge(request):
@@ -58,7 +60,7 @@ def submit_challenge(request):
         payload = {}
     ok, err = verify_solution(payload, settings.ALTCHA_HMAC_KEY, check_expires=True)
     # If the solution validates and hasn't already been seen, create/update their session dam
-    # expiration, as well as saving the challenge in cache.
+    # expiration and store client IP address, as well as saving the challenge in cache.
     if (isinstance(payload, dict) and ok
             and not cache.get(payload.get('challenge'))):
         challenge_expire_mins = getattr(settings, 'ALTCHA_CHALLENGE_EXPIRE_MINUTES', 2)
@@ -69,6 +71,8 @@ def submit_challenge(request):
             timeout=challenge_expire_mins*60)
         altcha_session_key = getattr(settings, 'ALTCHA_SESSION_KEY', 'altcha_verified')
         request.session[altcha_session_key] = time.time() + auth_expire_mins*60
+        # Store client IP address to verify on subsequent requests.
+        request.session['ip'] = get_client_ip(request)
         return JsonResponse({'success': True})
     # Otherwise, reject them.
     fail_msg = getattr(settings, 'ALTCHA_FAIL_MESSAGE', 'Challenge failed or no longer valid.')

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -94,12 +94,29 @@ class TestAltchaMiddleware:
         assert not AM.exclude_headers(request)
 
     @pytest.mark.django_db
-    def test_process_request_user_exempt(self, rf):
+    @patch('dam.middleware.get_client_ip', return_value='127.0.0.1')
+    def test_process_request_user_exempt(self, mock_get_ip, rf):
         mock_get_response = Mock()
         AM = AltchaMiddleware(mock_get_response)
         request = rf.get('/protected/')
-        request.session = {settings.ALTCHA_SESSION_KEY: time()+100}
+        request.session = {settings.ALTCHA_SESSION_KEY: time()+100,
+                           'ip': '127.0.0.1'}
         assert AM.process_request(request) is None
+        mock_get_ip.assert_called_once_with(request)
+
+    @pytest.mark.django_db
+    @patch('dam.middleware.get_client_ip', return_value='127.0.0.1')
+    def test_process_request_user_changed_ip_address(self, mock_get_ip, rf):
+        mock_get_response = Mock()
+        AM = AltchaMiddleware(mock_get_response)
+        request = rf.get('/protected/')
+        # Set IP address on session differing from client's IP.
+        request.session = {settings.ALTCHA_SESSION_KEY: time()+100,
+                           'ip': '111.111.111.111'}
+        response = AM.process_request(request)
+        assert response.status_code == 302
+        assert response.url == reverse('dam:challenge')+'?next=%2Fprotected%2F'
+        mock_get_ip.assert_called_once_with(request)
 
     @pytest.mark.django_db
     @pytest.mark.parametrize('path', [


### PR DESCRIPTION
This adds tracking of IP address in the user's stored session, so we can check if a session that has passed the Altcha challenge is used with a different IP address. If the IP address changes, the client will need to go through the challenge process again if they are trying to access a dam protected URL. The intent is to make it less easy for bots to reuse sessions that have passed the Altcha challenge.