### PR TITLE
Fix redirected url query parameters containing &amp;

### DIFF
--- a/dam/templates/dam_challenge.html
+++ b/dam/templates/dam_challenge.html
@@ -50,7 +50,7 @@
                     });
                     const result = await response.json();
                     if ("success" in result) {
-                        window.location.replace("{{ next_url }}");
+                        window.location.replace("{{ next_url|escapejs }}");
                     } else {
                         document.getElementById('altcha-content').innerHTML = `${result.error} {{ help_text|safe }}`;
                     }


### PR DESCRIPTION
Trying to visit a URL with query parameters such as https://texashistory.unt.edu/search/?nlow=1865&nhi=1876&t=fulltext and going through DAM, after passing the challenge, the client was redirected to https://texashistory.unt.edu/search/?nlow=1865&amp;nhi=1876&amp;t=fulltext. This prevents the `&amp;` in the redirected URL by escaping the URL value when written into the JavaScript of the template.